### PR TITLE
Add FBX support

### DIFF
--- a/io_scene_valvesource/GUI.py
+++ b/io_scene_valvesource/GUI.py
@@ -21,7 +21,7 @@
 import bpy
 from .utils import *
 from .export_smd import SmdExporter, SMD_OT_Compile
-from .update import SmdToolsUpdate # unused
+from .update import SmdToolsUpdate # comment this line out if making edits
 from .flex import *
 global p_cache
 
@@ -131,8 +131,8 @@ class SMD_PT_Scene(bpy.types.Panel):
 		row = col.row(align=True)
 		row.operator("wm.url_open",text=get_id("help",True),icon='HELP').url = "http://developer.valvesoftware.com/wiki/Blender_Source_Tools_Help#Exporting"
 		row.operator("wm.url_open",text=get_id("exportpanel_steam",True),icon='URL').url = "http://steamcommunity.com/groups/BlenderSourceTools"
-		#if "SmdToolsUpdate" in globals():
-		#	col.operator(SmdToolsUpdate.bl_idname,text=get_id("exportpanel_update",True),icon='URL')
+		if "SmdToolsUpdate" in globals():
+			col.operator(SmdToolsUpdate.bl_idname,text=get_id("exportpanel_update",True),icon='URL')
 
 class SMD_UL_ExportItems(bpy.types.UIList):
 	def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):

--- a/io_scene_valvesource/__init__.py
+++ b/io_scene_valvesource/__init__.py
@@ -27,7 +27,7 @@ bl_info = {
 	"location": "File > Import/Export, Scene properties",
 	"wiki_url": "http://steamcommunity.com/groups/BlenderSourceTools",
 	"tracker_url": "http://steamcommunity.com/groups/BlenderSourceTools/discussions/0/",
-	"description": "Importer and exporter for Valve Software's Source Engine. Supports SMD\VTA, DMX and QC."
+	"description": "Importer and exporter for Valve Software's Source Engine. Supports SMD\VTA, DMX, FBX, and QC."
 }
 
 import bpy, os
@@ -87,13 +87,13 @@ def menu_func_textedit(self,context):
 @bpy.app.handlers.persistent
 def scene_load_post(_):
 	def convert(id,*prop_groups):
-		prop_map = { "export_path":"path", "engine_path":"studiomdl_custom_path", "export_format":"format" }
+		prop_map = { "export_path":"path", "engine_path":"studiomdl_custom_path", "export_format":"format"}
 
 		for p_g in prop_groups:
-			for prop in [prop for prop in p_g.__dict__.keys() if prop[0] != '_']:
-				val = id.get("smd_" + (prop_map[prop] if prop in prop_map else prop))
-				if val != None:
-					id.vs[prop] = val
+			for prop in vars(p_g):
+				if prop.startswith('_'):
+					continue
+				val = id.get("smd_" + prop_map.get(prop, prop))
 			
 		for prop in id.keys():
 			if prop.startswith("smd_"):
@@ -175,6 +175,7 @@ class ValveSource_SceneProps(PropertyGroup):
 	dmx_format = EnumProperty(name=get_id("dmx_format"),description=get_id("dmx_format_tip"),items=tuple(formats),default='1')
 	
 	export_format = EnumProperty(name=get_id("export_format"),items=( ('SMD', "SMD", "Studiomdl Data" ), ('DMX', "DMX", "Datamodel Exchange" ) ),default='DMX')
+	export_format_fbx = EnumProperty(name=get_id("export_format"),items=( ('SMD', "SMD", "Studiomdl Data" ), ('DMX', "DMX", "Datamodel Exchange" ), ('FBX', "FBX", "Autodesk Fieldbox") ),default='DMX')
 	up_axis = EnumProperty(name=get_id("up_axis"),items=axes,default='Z',description=get_id("up_axis_tip"))
 	use_image_names = BoolProperty(name=get_id("ignore_materials"),description=get_id("ignore_materials_tip"),default=False)
 	layer_filter = BoolProperty(name=get_id("visible_only"),description=get_id("visible_only_tip"),default=False)

--- a/io_scene_valvesource/__init__.py
+++ b/io_scene_valvesource/__init__.py
@@ -90,10 +90,10 @@ def scene_load_post(_):
 		prop_map = { "export_path":"path", "engine_path":"studiomdl_custom_path", "export_format":"format"}
 
 		for p_g in prop_groups:
-			for prop in vars(p_g):
-				if prop.startswith('_'):
-					continue
-				val = id.get("smd_" + prop_map.get(prop, prop))
+			for prop in [prop for prop in p_g.__dict__.keys() if prop[0] != '_']:
+-				val = id.get("smd_" + (prop_map[prop] if prop in prop_map else prop))
+-				if val != None:
+-					id.vs[prop] = val
 			
 		for prop in id.keys():
 			if prop.startswith("smd_"):

--- a/io_scene_valvesource/export_smd.py
+++ b/io_scene_valvesource/export_smd.py
@@ -1309,7 +1309,7 @@ skeleton
 			try:
 				from io_scene_fbx.export_fbx_bin import save_single
 				print(srcResults)
-				save_single(self, bpy.context.scene, filepath=filepathExport, axis_up=bpy.context.scene.vs.up_axis, context_objects=srcResults, bake_space_transform=True)
+				save_single(self, bpy.context.scene, filepath=filepathExport, apply_unit_scale=True, apply_scale_options='FBX_SCALE_ALL', axis_up=bpy.context.scene.vs.up_axis, context_objects=srcResults, bake_space_transform=True)
 				written+=1
 			except ImportError:
 				print("Error loading the FBX library! Aborting...")

--- a/io_scene_valvesource/import_smd.py
+++ b/io_scene_valvesource/import_smd.py
@@ -25,6 +25,7 @@ from bpy.props import *
 from .utils import *
 from . import datamodel
 
+
 class SmdImporter(bpy.types.Operator, Logger):
 	bl_idname = "import_scene.smd"
 	bl_label = get_id("importer_title")

--- a/io_scene_valvesource/translations.py
+++ b/io_scene_valvesource/translations.py
@@ -350,8 +350,8 @@ _data = {
 	'ru': "Экспорт и импорт для движка Source. Поддерживаемые форматы: SMD/VTA, DMX, QC.",
 },
 'export_menuitem': {
-	'en': "Source Engine (.smd, .vta, .dmx)",
-	'ru': "Движок Source (.smd, .vta, .dmx)",
+	'en': "Source Engine (.smd, .vta, .dmx, .fbx)",
+	'ru': "Движок Source (.smd, .vta, .dmx, .fbx)",
 },
 'help': {
 	'ja': "ヘレプ",
@@ -556,9 +556,9 @@ _data = {
 	'ru': "Свойства группы {0} \"пересилены\"",
 },
 'exporter_title': {
-	'ja': "SMD/VTA/DMXをエクスポート",
-	'en': "Export SMD/VTA/DMX",
-	'ru': "Экспорт SMD/VTA/DMX",
+	'ja': "SMD/VTA/DMX/FBXをエクスポート",
+	'en': "Export SMD/VTA/DMX/FBX",
+	'ru': "Экспорт SMD/VTA/DMX/FBX",
 },
 'qc_compile_err_unknown': {
 	'en': "Compile of {0} failed. Check the console for details",
@@ -881,8 +881,8 @@ _data = {
 	'ru': "Активный объект для экспорта",
 },
 'exportroot_tip': {
-	'en': "The root folder into which SMD and DMX exports from this scene are written",
-	'ru': "Папка, куда будут экспортироваться SMD и DMX из текущей сцены",
+	'en': "The root folder into which SMD, DMX, and FBX exports from this scene are written",
+	'ru': "Папка, куда будут экспортироваться SMD, DMX, и FBX из текущей сцены",
 },
 'qc_compilenow': {
 	'ja': "今全てはコンパイル",

--- a/io_scene_valvesource/utils.py
+++ b/io_scene_valvesource/utils.py
@@ -201,7 +201,6 @@ def getEngineBranch():
 	if not (nameWorking == "bin"):
 		name = nameWorking.title().replace("Sdk","SDK")
 	else:
-		print("your MOM %s", nameWorking)
 		name = os.path.basename(os.path.dirname(os.path.dirname(bpy.path.abspath(path)))).title().replace("Sdk", "SDK")
 	dmx_versions = dmx_versions_source1.get(name)
 	fbx_support = fbx_support_source1.get(name) 


### PR DESCRIPTION
Allowing Blender Source Tools to export FBX in the same manner as SMD/DMX has a few major benefits. First of all, it's way more convenient by exporting each individual file separately through the export window. Secondly, it accelerates the texturing process since many programs such as Substance Painter don't support SMD/DMX anyways. The main reason FBX is the optimal format for CS:GO is that it can store two UV channels, which can be used with $decal in order to save on texture space. Since only CS:GO currently supports FBX, the option does not show up unless CS:GO is specified in the engine path.

The edit isn't really programmed *that* well (I'm still rather new to Python), however it works bug-free from my tests. It uses io_scene_fbx/export_fbx_bin.py for the backend. It also filters out things that Source's implementation of FBX does not support, such as vertex animation and animation actions.
![2018-05-05_11-39-10](https://user-images.githubusercontent.com/6201501/39674747-8444d1e8-5105-11e8-8e8e-19e622efa94a.gif)

![hlmv_2018-05-05_11-41-28](https://user-images.githubusercontent.com/6201501/39674765-bd496e90-5105-11e8-92fb-c5eef333eb01.png)
Test Suzanne exported using this edit. It uses a stock rock texture on UV0 and a baked AO map on the lightmap-packed UV1.

(unrelated bonus: BST now properly retrieves the names of the growing number of Source engine games that use formats such as bin/win32, bin/win64, etc)