### PR TITLE
Enforce bone hierarchy in SMD exporting

### DIFF
--- a/io_scene_valvesource/export_smd.py
+++ b/io_scene_valvesource/export_smd.py
@@ -808,7 +808,7 @@ class SmdExporter(bpy.types.Operator, Logger):
 		
 		if id.type in exportable_types:
 			# Bake reference mesh
-			data = bpy.data.meshes.new_from_object(id.evaluated_get(depsgraph))
+			data = bpy.data.meshes.new_from_object(id.evaluated_get(depsgraph),preserve_all_data_layers=True,depsgraph=depsgraph)
 			data.name = id.name + "_baked"			
 		
 			def put_in_object(id, data, quiet=False):


### PR DESCRIPTION
When attempting to export a particular rigged mesh, I kept encountering an error: 
`Blender Source Tools: exporting skeleton_name
- Baking...
- D:\Documents\3D Models\Commissions\xxx\decompiled 0.62\smd2\anims\ragdoll.smd
Traceback (most recent call last):
  File "C:\Users\Grey Ruessler\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\io_scene_valvesource\export_smd.py", line 211, in execute
    self.exportId(context, exportable.get_id())
  File "C:\Users\Grey Ruessler\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\io_scene_valvesource\export_smd.py", line 563, in exportId
    self.files_exported += write_func(id, bake_results, self.sanitiseFilename(export_name), path)
  File "C:\Users\Grey Ruessler\AppData\Roaming\Blender Foundation\Blender\2.80\scripts\addons\io_scene_valvesource\export_smd.py", line 990, in writeSMD
    line += str(self.bone_ids[parent.name])
KeyError: 'ValveBiped.Bip01_Pelvis'`

Based on this KeyError, I came to the conclusion that for one reason or another, ValveBiped.Bip01_Pelvis wasn't iterated through first, and thus not added to the bone_ids array. As iteration is done sequentially, this then implies that the previous inline function wasn't necessarily hitting the root bones first.

My replacement, though less elegant, ensures that the proper hierarchy is followed when the bone tree is flattened; this alleviates the KeyError issue, and should produce more consistent results overall, especially with more than one root bone.

tl;dr
**self.armature.pose.bones isn't guaranteed to be in order**

