### PR TITLE
Partial Source 2 cloth attribute export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# BlenderSourceTools
+Modified version of the Blender Source Tools with some Source 2 specific features.
+
+Original version: https://github.com/Artfunkel/BlenderSourceTools
+
+__Warning: This version is experimental and untested. It may corrupt your .blend files or have other nasty side effects. Please back up your files before using.__
+
+## Usage
+1. Extract the `io_scene_valvesource` directory to `AppData\Roaming\Blender Foundation\Blender\2.83\scripts\addons\`
+2. Only DMX version Binary 9 Model 22 is supported
+
+## Features
+* Support for vertex float maps
+ 
+ Used for cloth attributes. To add a map, use the + button in the *Float Maps* section of the *Source Engine Exportables* pane. Optionally, the output range can be rescaled with the min and max settings. Paint the map using the weight paint tool.
+
+* Bone axis reorientation
+
+Source 2 expects the X axis of bones to point toward the next bone in a chain, enabling the *Rotate Bone X-axis forward* option under *Source Engine Export* will rotate all bones on export, so that the X-axis will face the original Y-axis.
+
+* Model scaling
+
+Scales the entire model on export. Located under *Source Engine Export*. A value of approximately 39 will scale models from metric to inches.
+
+* Forward parity
+
+Located under *Source Engine Export*. DMX option that determines which axis will map to forward (positive X-axis) when imported to the engine.
+
+* Export direct flex keyframes
+
+Exports flex animations directly to DMX without binding them to bones. Located under *Source Engine Export*. To use, assign an action with animated shape keys both to the mesh and the armature. Currently the exporter uses the length of the skeletal animation keyframes in the action, so place bone keyframes at both the start and end of the animation. This likely does not support NLA or any advanced flex features, and does not currently filter out unused shape keys.

--- a/io_scene_valvesource/GUI.py
+++ b/io_scene_valvesource/GUI.py
@@ -112,6 +112,9 @@ class SMD_PT_Scene(bpy.types.Panel):
 				col.prop(scene.vs,"dmx_weightlink_threshold",slider=True)
 				col.enabled = shouldExportDMX()
 
+				row = l.row().split(factor=0.33)
+				row.label(text=GetCustomPropName(scene.vs,"forward_parity",":"))
+				row.row().prop(scene.vs,"forward_parity", expand=True)
 				l.row().prop(scene.vs,"model_scale", expand=True)
 				l.row().prop(scene.vs,"bone_swap_forward_axis", expand=True)
 

--- a/io_scene_valvesource/GUI.py
+++ b/io_scene_valvesource/GUI.py
@@ -117,6 +117,8 @@ class SMD_PT_Scene(bpy.types.Panel):
 				row.row().prop(scene.vs,"forward_parity", expand=True)
 				l.row().prop(scene.vs,"model_scale", expand=True)
 				l.row().prop(scene.vs,"bone_swap_forward_axis", expand=True)
+				l.row().prop(scene.vs,"export_keyframe_scale", expand=True)
+				l.row().prop(scene.vs,"export_keyframe_flex", expand=True)
 
 		else:
 			row = l.split(factor=0.33)

--- a/io_scene_valvesource/__init__.py
+++ b/io_scene_valvesource/__init__.py
@@ -178,6 +178,8 @@ class ValveSource_SceneProps(PropertyGroup):
 	up_axis : EnumProperty(name=get_id("up_axis"),items=axes,default='Z',description=get_id("up_axis_tip"))
 	forward_parity : EnumProperty(name=get_id("forward_parity"),items=axes_signed,default='+X',description=get_id("forward_parity_tip"))
 	bone_swap_forward_axis : BoolProperty(name=get_id("bone_swap_forward_axis"),default=False,description=get_id("bone_swap_forward_axis_tip"))
+	export_keyframe_scale : BoolProperty(name=get_id("export_keyframe_scale"),default=False,description=get_id("export_keyframe_scale_tip"))
+	export_keyframe_flex : BoolProperty(name=get_id("export_keyframe_flex"),default=False,description=get_id("export_keyframe_flex_tip"))
 	model_scale : FloatProperty(name=get_id("model_scale"),default=1.0,soft_min=0.1,soft_max=100,step=10,description=get_id("model_scale_tip"))
 	material_path : StringProperty(name=get_id("dmx_mat_path"),description=get_id("dmx_mat_path_tip"))
 	export_list_active : IntProperty(name=get_id("active_exportable"),default=0,min=0,update=export_active_changed)

--- a/io_scene_valvesource/__init__.py
+++ b/io_scene_valvesource/__init__.py
@@ -60,7 +60,7 @@ class ValveSource_Exportable(bpy.types.PropertyGroup):
 	ob_type : StringProperty()
 	icon : StringProperty()
 	item_name : StringProperty()
-	
+
 	def get_id(self):
 		try:
 			if self.ob_type == 'COLLECTION':
@@ -94,11 +94,11 @@ def scene_load_post(_):
 				val = id.get("smd_" + (prop_map[prop] if prop in prop_map else prop))
 				if val != None:
 					id.vs[prop] = val
-			
+
 		for prop in id.keys():
 			if prop.startswith("smd_"):
 				del id[prop]
-				
+
 	for s in bpy.data.scenes:
 		if hasattr(s,"vs"):
 			convert(s,ValveSource_SceneProps)
@@ -128,10 +128,10 @@ def export_active_changed(self, context):
 		return
 
 	id = get_active_exportable(context).get_id()
-	
+
 	if type(id) == bpy.types.Collection and id.vs.mute: return
 	for ob in context.scene.objects: ob.select_set(False)
-	
+
 	if type(id) == bpy.types.Collection:
 		context.view_layer.objects.active = id.objects[0]
 		for ob in id.objects: ob.select_set(True)
@@ -170,12 +170,14 @@ class ValveSource_SceneProps(PropertyGroup):
 	qc_compile : BoolProperty(name=get_id("qc_compileall"),description=get_id("qc_compileall_tip"),default=False)
 	qc_path : StringProperty(name=get_id("qc_path"),description=get_id("qc_path_tip"),default="//*.qc",subtype="FILE_PATH")
 	engine_path : StringProperty(name=get_id("engine_path"),description=get_id("engine_path_tip"), subtype="DIR_PATH",update=engine_path_changed)
-	
+
 	dmx_encoding : EnumProperty(name=get_id("dmx_encoding"),description=get_id("dmx_encoding_tip"),items=tuple(encodings),default='2')
 	dmx_format : EnumProperty(name=get_id("dmx_format"),description=get_id("dmx_format_tip"),items=tuple(formats),default='1')
-	
+
 	export_format : EnumProperty(name=get_id("export_format"),items=( ('SMD', "SMD", "Studiomdl Data" ), ('DMX', "DMX", "Datamodel Exchange" ) ),default='DMX')
 	up_axis : EnumProperty(name=get_id("up_axis"),items=axes,default='Z',description=get_id("up_axis_tip"))
+	bone_swap_forward_axis : BoolProperty(name=get_id("bone_swap_forward_axis"),default=False,description=get_id("bone_swap_forward_axis_tip"))
+	model_scale : FloatProperty(name=get_id("model_scale"),default=1.0,soft_min=0.1,soft_max=100,step=10,description=get_id("model_scale_tip"))
 	material_path : StringProperty(name=get_id("dmx_mat_path"),description=get_id("dmx_mat_path_tip"))
 	export_list_active : IntProperty(name=get_id("active_exportable"),default=0,min=0,update=export_active_changed)
 	export_list : CollectionProperty(type=ValveSource_Exportable,options={'SKIP_SAVE','HIDDEN'})
@@ -278,18 +280,18 @@ _classes = (
 	flex.AddCorrectiveShapeDrivers,
 	flex.ActiveDependencyShapes,
 	update.SmdToolsUpdate,
-	export_smd.SMD_OT_Compile, 
-	export_smd.SmdExporter, 
+	export_smd.SMD_OT_Compile,
+	export_smd.SmdExporter,
 	import_smd.SmdImporter)
 
 def register():
 	from bpy.utils import register_class
 	for cls in _classes:
 		register_class(cls)
-	
+
 	from . import translations
 	bpy.app.translations.register(__name__,translations.translations)
-	
+
 	bpy.types.TOPBAR_MT_file_import.append(menu_func_import)
 	bpy.types.TOPBAR_MT_file_export.append(menu_func_export)
 	bpy.types.MESH_MT_shape_key_context_menu.append(menu_func_shapekeys)
@@ -297,13 +299,13 @@ def register():
 	hook_scene_update()
 	bpy.app.handlers.load_post.append(scene_load_post)
 	depsgraph_update_post.append(scene_load_post) # handles enabling the add-on after the scene is loaded
-		
+
 	try: bpy.ops.wm.addon_disable('EXEC_SCREEN',module="io_smd_tools")
 	except: pass
-	
+
 	def make_pointer(prop_type):
 		return PointerProperty(name=get_id("settings_prop"),type=prop_type)
-		
+
 	bpy.types.Scene.vs = make_pointer(ValveSource_SceneProps)
 	bpy.types.Object.vs = make_pointer(ValveSource_ObjectProps)
 	bpy.types.Armature.vs = make_pointer(ValveSource_ArmatureProps)
@@ -323,7 +325,7 @@ def unregister():
 	bpy.types.TEXT_MT_edit.remove(menu_func_textedit)
 
 	bpy.app.translations.unregister(__name__)
-	
+
 	from bpy.utils import unregister_class
 	for cls in reversed(_classes):
 		unregister_class(cls)

--- a/io_scene_valvesource/__init__.py
+++ b/io_scene_valvesource/__init__.py
@@ -204,9 +204,15 @@ class ExportableProps():
 	vertex_animations : CollectionProperty(name=get_id("vca_group_props"),type=ValveSource_VertexAnimation)
 	active_vertex_animation : IntProperty(default=-1)
 
+class VertexMapRemap(PropertyGroup):
+	group : StringProperty(name="Group name",default="")
+	min : FloatProperty(name="Min",description="Maps to 0.0",default=0.0)
+	max : FloatProperty(name="Max",description="Maps to 1.0",default=1.0)
+
 class ValveSource_ObjectProps(ExportableProps,PropertyGroup):
 	action_filter : StringProperty(name=get_id("action_filter"),description=get_id("action_filter_tip"))
 	triangulate : BoolProperty(name=get_id("triangulate"),description=get_id("triangulate_tip"),default=False)
+	vertex_map_remaps :  CollectionProperty(name="Vertes map remaps",type=VertexMapRemap)
 
 class ValveSource_ArmatureProps(PropertyGroup):
 	implicit_zero_bone : BoolProperty(name=get_id("dummy_bone"),default=True,description=get_id("dummy_bone_tip"))
@@ -244,6 +250,7 @@ class ValveSource_TextProps(CurveTypeProps,PropertyGroup):
 	pass
 
 _classes = (
+	VertexMapRemap,
 	ValveSource_Exportable,
 	ValveSource_SceneProps,
 	ValveSource_VertexAnimation,

--- a/io_scene_valvesource/__init__.py
+++ b/io_scene_valvesource/__init__.py
@@ -176,6 +176,7 @@ class ValveSource_SceneProps(PropertyGroup):
 
 	export_format : EnumProperty(name=get_id("export_format"),items=( ('SMD', "SMD", "Studiomdl Data" ), ('DMX', "DMX", "Datamodel Exchange" ) ),default='DMX')
 	up_axis : EnumProperty(name=get_id("up_axis"),items=axes,default='Z',description=get_id("up_axis_tip"))
+	forward_parity : EnumProperty(name=get_id("forward_parity"),items=axes_signed,default='+X',description=get_id("forward_parity_tip"))
 	bone_swap_forward_axis : BoolProperty(name=get_id("bone_swap_forward_axis"),default=False,description=get_id("bone_swap_forward_axis_tip"))
 	model_scale : FloatProperty(name=get_id("model_scale"),default=1.0,soft_min=0.1,soft_max=100,step=10,description=get_id("model_scale_tip"))
 	material_path : StringProperty(name=get_id("dmx_mat_path"),description=get_id("dmx_mat_path_tip"))

--- a/io_scene_valvesource/export_smd.py
+++ b/io_scene_valvesource/export_smd.py
@@ -1319,8 +1319,8 @@ skeleton
 		if source2:
 			DmeAxisSystem = DmeModel["axisSystem"] = dm.add_element("axisSystem","DmeAxisSystem","AxisSys" + armature_name)
 			DmeAxisSystem["upAxis"] = axes_lookup_source2[bpy.context.scene.vs.up_axis]
-			DmeAxisSystem["forwardParity"] = 1 # ??
-			DmeAxisSystem["coordSys"] = 0 # ??
+			DmeAxisSystem["forwardParity"] = axes_lookup_source2_signed[bpy.context.scene.vs.forward_parity]
+			DmeAxisSystem["coordSys"] = 0 # ?? - Maybe global vs local coordinates
 
 		DmeModel["transform"] = makeTransform("",Matrix(),DmeModel.name + "transform")
 

--- a/io_scene_valvesource/export_smd.py
+++ b/io_scene_valvesource/export_smd.py
@@ -749,6 +749,9 @@ class SmdExporter(bpy.types.Operator, Logger):
 		ops.object.parent_clear(type='CLEAR_KEEP_TRANSFORM')
 		id.matrix_world = Matrix.Translation(top_parent.location).inverted() @ getUpAxisMat(bpy.context.scene.vs.up_axis).inverted() @ id.matrix_world
 
+		if shouldExportDMX() and bpy.context.scene.vs.model_scale != 1.0:
+			id.matrix_world @= Matrix.Diagonal(Vector.Fill(4, bpy.context.scene.vs.model_scale))
+
 		if id.type == 'ARMATURE':
 			for posebone in id.pose.bones: posebone.matrix_basis.identity()
 			if self.armature and self.armature != id:

--- a/io_scene_valvesource/translations.py
+++ b/io_scene_valvesource/translations.py
@@ -864,6 +864,9 @@ _data = {
 	'en': "Target Up Axis",
 	'ru': "Направление \"Вверх\"",
 },
+'forward_parity': {
+	'en': "Forward Parity",
+},
 'bone_swap_forward_axis': {
 	'en': "Rotate Bone X-axis Forward",
 },
@@ -901,6 +904,9 @@ _data = {
 'up_axis_tip': {
 	'en': "Use for compatibility with data from other 3D tools",
 	'ru': "Используется для совместимости с экспортами из Maya и других 3D-пакетов",
+},
+'forward_parity_tip': {
+	'en': "Which axis is forward on the model. The Source 2 tools will map this to the positive X-axis",
 },
 'bone_swap_forward_axis_tip': {
 	'en': "Rotates all bones so that the resulting X-axis faces the direction of the bone (Y-axis in Blender), per the Source engine convension. Used for better compatibility with some Source engine features",

--- a/io_scene_valvesource/translations.py
+++ b/io_scene_valvesource/translations.py
@@ -870,6 +870,12 @@ _data = {
 'bone_swap_forward_axis': {
 	'en': "Rotate Bone X-axis Forward",
 },
+'export_keyframe_scale': {
+	'en': "Export Bone Scale Keyframes (non-functional)",
+},
+'export_keyframe_flex': {
+	'en': "Export Direct Flex Keyframes",
+},
 'model_scale': {
 	'en': "Model Scale",
 },
@@ -910,6 +916,12 @@ _data = {
 },
 'bone_swap_forward_axis_tip': {
 	'en': "Rotates all bones so that the resulting X-axis faces the direction of the bone (Y-axis in Blender), per the Source engine convension. Used for better compatibility with some Source engine features",
+},
+'export_keyframe_scale_tip': {
+	'en': "Export skeletal animations with scale in addition to location and rotation",
+},
+'export_keyframe_flex_tip': {
+	'en': "Export keyframes that directly drive flexes, instead of ones indirectly driven through bones",
 },
 'model_scale_tip': {
 	'en': "Scales the model by a multiplier",

--- a/io_scene_valvesource/translations.py
+++ b/io_scene_valvesource/translations.py
@@ -864,6 +864,12 @@ _data = {
 	'en': "Target Up Axis",
 	'ru': "Направление \"Вверх\"",
 },
+'bone_swap_forward_axis': {
+	'en': "Rotate Bone X-axis Forward",
+},
+'model_scale': {
+	'en': "Model Scale",
+},
 'dmx_format': {
 	'ja': "DMXのフォーマット",
 	'en': "DMX format",
@@ -895,6 +901,12 @@ _data = {
 'up_axis_tip': {
 	'en': "Use for compatibility with data from other 3D tools",
 	'ru': "Используется для совместимости с экспортами из Maya и других 3D-пакетов",
+},
+'bone_swap_forward_axis_tip': {
+	'en': "Rotates all bones so that the resulting X-axis faces the direction of the bone (Y-axis in Blender), per the Source engine convension. Used for better compatibility with some Source engine features",
+},
+'model_scale_tip': {
+	'en': "Scales the model by a multiplier",
 },
 'smd_format': {
 	'ja': "対象のエンジン",
@@ -1005,7 +1017,7 @@ _data = {
 },
 }
 
-def _get_ids():	
+def _get_ids():
 	ids = {}
 	for id,values in _data.items():
 		ids[id] = values['en']

--- a/io_scene_valvesource/utils.py
+++ b/io_scene_valvesource/utils.py
@@ -193,6 +193,54 @@ def getDmxVersionsForSDK():
 
 vertex_maps = ["valvesource_vertex_paint", "valvesource_vertex_blend", "valvesource_vertex_blend1"]
 
+# Per vertex Source 2 DMX cloth maps
+cloth_maps = [
+	"cloth_enable",
+	"cloth_animation_attract",
+	"cloth_animation_force_attract",
+	"cloth_goal_strength",
+	"cloth_goal_strength_v2",
+	"cloth_goal_damping",
+	"cloth_drag",
+	"cloth_drag_v2",
+	"cloth_mass",
+	"cloth_gravity",
+	"cloth_gravity_z",
+	"cloth_collision_radius",
+	"cloth_ground_collision",
+	"cloth_ground_friction",
+	"cloth_use_rods",
+	"cloth_make_rods",
+	"cloth_anchor_free_rotate",
+	"cloth_volumetric",
+	"cloth_suspenders",
+	"cloth_bend_stiffness",
+	"cloth_stray_radius_inv",
+	"cloth_stray_radius",
+	"cloth_stray_radius_stretchiness",
+	"cloth_antishrink",
+	"cloth_shear_resistance",
+	"cloth_stretch",
+	"cloth_friction"
+]
+
+def findDmxClothVertexGroups(ob):
+	groups = []
+	for vgroup in ob.vertex_groups:
+		if vgroup.name in cloth_maps:
+			groups.append(vgroup)
+			
+		elif vgroup.name.startswith("cloth_collision_layer_"):
+			for n in range(16):
+				if vgroup.name == f"cloth_collision_layer_{n}":
+					groups.append(vgroup)
+					break
+			
+		elif vgroup.name.startswith("cloth_vertex_set_"):
+			groups.append(vgroup)
+
+	return groups
+
 def getDmxKeywords(format_version):
 	if format_version >= 22:
 		return {

--- a/io_scene_valvesource/utils.py
+++ b/io_scene_valvesource/utils.py
@@ -193,8 +193,8 @@ def getDmxVersionsForSDK():
 
 vertex_maps = ["valvesource_vertex_paint", "valvesource_vertex_blend", "valvesource_vertex_blend1"]
 
-# Per vertex Source 2 DMX cloth maps
-cloth_maps = [
+# Per vertex Source 2 DMX maps
+vertex_float_maps = [
 	"cloth_enable",
 	"cloth_animation_attract",
 	"cloth_animation_force_attract",
@@ -222,12 +222,16 @@ cloth_maps = [
 	"cloth_shear_resistance",
 	"cloth_stretch",
 	"cloth_friction"
+	
+	# TODO add way to set up groups manually
+	# cloth_collision_layer_%d - 0 through 15
+	# cloth_vertex_set_%s - name
 ]
 
 def findDmxClothVertexGroups(ob):
 	groups = []
 	for vgroup in ob.vertex_groups:
-		if vgroup.name in cloth_maps:
+		if vgroup.name in vertex_float_maps:
 			groups.append(vgroup)
 			
 		elif vgroup.name.startswith("cloth_collision_layer_"):


### PR DESCRIPTION
This will export any found cloth attributes to DMX version 22 files using vertex groups, if the mesh is has the `cloth_enable` attribute assigned to it.

Many float valued per-vertex attributes are available (see utils.py:197). The exporter looks for vertex groups with the same name as each attribute. 

Since it uses vertex groups, it is not possible to assign full range of values to all attributes since Blenders vertex group weights are normalized to [0, 1].

https://steamcommunity.com/groups/BlenderSourceTools/discussions/1/2626095297423520749/