### PR TITLE
Enable Blender preset system for imports

### DIFF
--- a/io_scene_valvesource/import_smd.py
+++ b/io_scene_valvesource/import_smd.py
@@ -29,7 +29,7 @@ class SmdImporter(bpy.types.Operator, Logger):
 	bl_idname = "import_scene.smd"
 	bl_label = get_id("importer_title")
 	bl_description = get_id("importer_tip")
-	bl_options = {'UNDO'}
+	bl_options = {'UNDO', 'PRESET'}
 	
 	qc = None
 	smd = None


### PR DESCRIPTION
This allows users to create custom presets for the operator settings. The preset dropdown is displayed above the operator props.

![image](https://user-images.githubusercontent.com/3680681/145430754-6b3406ed-ccaa-4bba-82fc-e97fb971eaf5.png)
