### PR TITLE
Fix issues related to writing particle files (datamodel.py PR)

### DIFF
--- a/io_scene_valvesource/datamodel.py
+++ b/io_scene_valvesource/datamodel.py
@@ -236,7 +236,7 @@ class Color(Vector4):
 	type_str = "iiii"
 	def tobytes(self):
 		out = bytes()
-		for i in self:
+		for i in range(len(self.type_str)):
 			out += bytes(int(self[i]))
 		return out
 class _ColorArray(_Vector4Array):
@@ -712,7 +712,8 @@ class DataModel:
 			elem._users = 0
 		def _count_child_elems(elem):
 			if elem in out_elems: return
-
+			if(elem.get("material")):
+				elem["material"] = elem["material"].replace('\\', '\\\\')
 			out_elems.add(elem)
 			for name in elem:
 				attr = elem[name]
@@ -726,6 +727,9 @@ class DataModel:
 						if item not in out_elems:
 							_count_child_elems(item)
 						item._users += 1
+				elif t == Color:
+					for i in range(len(attr.type_str)):
+						attr[i] = int(attr[i])
 		_count_child_elems(self.root)
 		
 		if self.encoding in ["binary", "binary_proto"]:


### PR DESCRIPTION
Simply getting a particle out of TF2 and then reading and writing it results in several issues

```
import datamodel

test = datamodel.load('bullet_tracers.pcf')
test.write('bullet_tracers_kv.pcf', 'keyvalues', 2)
```

Initially, datamodel.py will fail to write anything

```
Traceback (most recent call last):
  File "stupidtest.py", line 4, in <module>
    test2.write('test5.pcf', 'binary', 2)
  File "L:\colours.tf\datamodel.py", line 749, in write
    dm = self.echo(encoding,encoding_ver)
  File "L:\colours.tf\datamodel.py", line 735, in echo
    self._write_element_props()
  File "L:\colours.tf\datamodel.py", line 674, in _write_element_props
    self._write(attr,elem)
  File "L:\colours.tf\datamodel.py", line 633, in _write
    self.out.write(bytes.join(b'',[item.tobytes() for item in value]))
  File "L:\colours.tf\datamodel.py", line 633, in <listcomp>
    self.out.write(bytes.join(b'',[item.tobytes() for item in value]))
  File "L:\colours.tf\datamodel.py", line 240, in tobytes
    out += bytes(int(self[i]))
TypeError: list indices must be integers or slices, not float
```

I fixed this by using the length of `type_str` to iterate on the class (this might be stupid but it worked lol)

Opening this new file in the particle editor results in the game failing to read it due to it outputting colours as floats rather than ints:

```"tint clamp max" "color" "255.0 255.0 255.0 255.0"```

I fixed this by just typecasting every `Color` value to int when writing.

Additionally, single backslashes are completely ignored when reading materials so they have to be escaped twice in order for the game to read it correctly.

It should be noted that reading, writing a keyvalues version, and then loading it in the particle editor and pressing save (so it saves in a binary format) results in a byte identical file. 
![image](https://user-images.githubusercontent.com/4157860/146479319-1dd33fe2-e51f-4dc0-95cf-6b800ff4b28c.png)

Writing it in a binary format using datamodel.py results in the game crashing as soon as it tries to load it, which I don't know how to fix lol

As a side note, datamodel.py should probably be its own repository, considering there are a fair few projects (including my own) that depend on this library that have nothing to do with BlenderSourceTools.