### PR TITLE
Export of objects within the collections having same name as objects. Exclusion of linked collections from export.

### DIFF
--- a/io_scene_valvesource/export_smd.py
+++ b/io_scene_valvesource/export_smd.py
@@ -174,7 +174,10 @@ class SmdExporter(bpy.types.Operator, Logger):
 				prev_mode = prev_mode.split('_')
 				prev_mode.reverse()
 				prev_mode = "_".join(prev_mode)
-			ops.object.mode_set(mode='OBJECT')
+				
+			# Check for current mode needed because this wouldn't work with linked collections/objects
+			if bpy.context.mode != 'OBJECT':
+				ops.object.mode_set(mode='OBJECT')
 		
 		State.update_scene()
 		self.bake_results = []
@@ -250,7 +253,9 @@ class SmdExporter(bpy.types.Operator, Logger):
 			if bpy.app.debug_value <= 1: ops.ed.undo()
 			
 			if prev_mode:
-				ops.object.mode_set(mode=prev_mode)
+				# Check for current mode needed because this wouldn't work with linked collections/objects
+				if prev_mode != context.mode:
+					ops.object.mode_set(mode=prev_mode)
 			if prev_hidden:
 				context.scene.objects[prev_hidden].hide_viewport = True
 			context.scene.update_tag()

--- a/io_scene_valvesource/utils.py
+++ b/io_scene_valvesource/utils.py
@@ -489,24 +489,23 @@ def hasFlexControllerSource(source):
 
 def getExportablesForObject(ob):
 	# objects can be reallocated between yields, so capture the name locally
-	ob_name = ob.name
+	ob_param = ob
 	seen = set()
 
-	while len(seen) < len(bpy.context.scene.vs.export_list):
-		# Handle the exportables list changing between yields by re-evaluating the whole thing
-		for exportable in bpy.context.scene.vs.export_list:
-			item_name = exportable.item.name
-			if item_name in seen:
-				continue
-			seen.add(item_name)
+	# Handle the exportables list changing between yields by re-evaluating the whole thing
+	for exportable in bpy.context.scene.vs.export_list:
+		item_name = exportable.item
+		if item_name in seen:
+			continue
+		seen.add(item_name)
 
-			if exportable.ob_type == 'COLLECTION' and not exportable.item.vs.mute and ob_name in exportable.item.objects:
-				yield exportable
-				break
+		if exportable.ob_type == 'COLLECTION' and not exportable.item.vs.mute and ob_param.name in exportable.item.objects:
+			yield exportable
+			break
 
-			if item_name == ob_name:
-				yield exportable
-				break
+		if item_name == ob_param:
+			yield exportable
+			break
 
 def getSelectedExportables():
 	seen = set()
@@ -538,7 +537,10 @@ def make_export_list(scene):
 			for obj in [obj for obj in group.objects if obj.name in State.exportableObjects]:
 				if not group.vs.mute and obj.type != 'ARMATURE' and obj.name in ungrouped_objects:
 					ungrouped_objects.remove(obj.name)
-				valid = True
+
+				# Linked collections cannot be exported so excluding them here
+				if group.library is None: 
+					valid = True
 			if valid:
 				scene_groups.append(group)
 				


### PR DESCRIPTION
The bug with common names for objects and collections was reported [here](https://steamcommunity.com/groups/BlenderSourceTools/discussions/0/3773490215221398139/)

Trying to export non-editable (linked) collections leads to error and aborted export, so added check for it.