### PR TITLE
Change Default Import Bone Shape

### DIFF
--- a/io_scene_valvesource/import_smd.py
+++ b/io_scene_valvesource/import_smd.py
@@ -53,7 +53,7 @@ class SmdImporter(bpy.types.Operator, Logger):
 		default='APPEND')
 	upAxis : EnumProperty(name="Up Axis",items=axes,default='Z',description=get_id("importer_up_tip"))
 	rotMode : EnumProperty(name=get_id("importer_rotmode"),items=( ('XYZ', "Euler", ''), ('QUATERNION', "Quaternion", "") ),default='XYZ',description=get_id("importer_rotmode_tip"))
-	boneMode : EnumProperty(name=get_id("importer_bonemode"),items=(('NONE','Default',''),('ARROWS','Arrows',''),('SPHERE','Sphere','')),default='SPHERE',description=get_id("importer_bonemode_tip"))
+	boneMode : EnumProperty(name=get_id("importer_bonemode"),items=(('NONE','Default',''),('ARROWS','Arrows',''),('SPHERE','Sphere','')),default='ARROWS',description=get_id("importer_bonemode_tip"))
 	
 	def execute(self, context):
 		pre_obs = set(bpy.context.scene.objects)


### PR DESCRIPTION
This PR will will change the default bone shape to be arrows and not spheres. This change will be helpful for new and existing modders to understand and visualize bone orientation.

Sphere do not give a clear visual to how the bone is orientated.
![image](https://github.com/user-attachments/assets/91970ae4-5cea-42a0-960a-8422ff6478db)

Compared to arrows where you can clearly see the axis and what the orientation of the bone is.
![image](https://github.com/user-attachments/assets/9ecf7aa9-041b-42db-8e1b-38e44152ea76)

Bone orientation is important for animations if using include models or creating animations or procedural bones like jigglebones or quaternion interpolated bones.