### PR TITLE
Optimizing validate_element in datamodel.py for faster loading of large dmx files

### DIFF
--- a/io_scene_valvesource/datamodel.py
+++ b/io_scene_valvesource/datamodel.py
@@ -569,6 +569,8 @@ class DataModel:
 		self.format_ver = format_ver
 		
 		self.__elements = []
+		self.__elements_set = set()
+		self.__elements_placeholders_set = set()
 		self.__prefix_attributes = Element(self,"")
 		self.root = None
 		self.allow_random_ids = True
@@ -578,6 +580,11 @@ class DataModel:
 
 	def validate_element(self,elem):
 		if elem._is_placeholder:
+			return
+		
+		if not elem in self.__elements_set:
+			return
+		if elem in self.__elements_placeholders_set:
 			return
 
 		try:
@@ -594,6 +601,10 @@ class DataModel:
 		elem = Element(self,name,elemtype,id,_is_placeholder)
 		self.validate_element(elem)
 		self.elements.append(elem)
+		if _is_placeholder:
+			self.__elements_placeholders_set.add(elem)
+		else:
+			self.__elements_set.add(elem)
 		elem.datamodel = self
 		if len(self.elements) == 1: self.root = elem
 		return elem


### PR DESCRIPTION
I had a scenario where I was trying to load a relatively large dmx file using datamodel.py and it was taking a very long time. I noticed that validate_element is using an O(n) lookup for every element added during load, so I added some sets to convert this to O(1), unless validation fails.

## Time comparison
In the case of my dmx file (SFM session, ~57MB), these were the load time before and after the change:
- before: 1hr+ (I left it running for 1 hour and it's still not finished)
- after: 10 sec

Let me know if you'd like me to make any adjustments.