### PR TITLE
Write the vta once per export, not once per flexed mesh

### DIFF
--- a/io_scene_valvesource/export_smd.py
+++ b/io_scene_valvesource/export_smd.py
@@ -1,4 +1,4 @@
-﻿#  Copyright (c) 2014 Tom Edwards contact@steamreview.org
+#  Copyright (c) 2014 Tom Edwards contact@steamreview.org
 #
 # ##### BEGIN GPL LICENSE BLOCK #####
 #
@@ -1235,7 +1235,7 @@ class SmdExporter(bpy.types.Operator, Logger):
 
 		written = 1
 		if filetype == 'smd':
-			for bake in [bake for bake in bake_results if bake.shapes]:
+			if any(bake.shapes for bake in bake_results):
 				written += self.writeSMD(id,bake_results,name,filepath,filetype='vta')
 			for name,vca in bake_results[0].vertex_animations.items():
 				written += self.writeVCA(name,vca,filepath)


### PR DESCRIPTION
writeSMD() ends by looping over every bake result that has shapes and calling itself for each, but the loop variable is not used and each call is handed the full bake_results along with the same name/filepath:

```
written = 1
    if filetype == 'smd':
        for bake in [bake for bake in bake_results if bake.shapes]:\n
            written += self.writeSMD(id,bake_results,name,filepath,filetype='vta'
```
The filetype == 'vta' branch already walks through bake_results to collect shape_names and to write each mesh's deltas, so one call makes the whole file. Extra iterations re-read the meshes and rewrite the same path, producing the same bytes.

An export with four flexed meshes writes its VTA four times, prints the path four times, and takes four times as long to export. Nothing downstream is affected, but the work is wasted and unnecessary. It also inflates the file count, as each recursive call will return 1 because writeSMD returns 1 + N for N flexed meshes where two files were written. A model with four flexed meshes will then report 5 files exported for one .smd and one .vta.

This patch will replace the loop with the presence check it was originally doing the work of.